### PR TITLE
Fix allow use model altough not visible

### DIFF
--- a/lib/rails_admin/config/actions/base.rb
+++ b/lib/rails_admin/config/actions/base.rb
@@ -32,7 +32,7 @@ module RailsAdmin
           bindings[:abstract_model].nil? || (
             (only.nil? || [only].flatten.collect(&:to_s).include?(bindings[:abstract_model].to_s)) &&
             ![except].flatten.collect(&:to_s).include?(bindings[:abstract_model].to_s) &&
-            bindings[:abstract_model].config.with(bindings).visible?
+            !bindings[:abstract_model].config.excluded?
           )
         end
 


### PR DESCRIPTION
This will allow models to be used regardless of the visible status